### PR TITLE
Ignore link paths based on partial matches

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This is a [webpack](https://webpack.js.org/) loader for Polymer applications and
   excludes: RegEx (optional),
   options: {
     ignoreLinks: Array (optional),
+    ignoreLinksFromPartialMatches: Array (optional),
     ignorePathReWrite: Array (optional)
   },
   loader: 'component-loader'
@@ -28,6 +29,10 @@ A regular expression for files that the loader should exclude. NOTE: Files impor
 #### ignoreLinks: Array
 
 An array of paths to be ignored when dynamically imported. When the component loader comes across a `<link>` in your components it dynamically imports the value of href attribute.  
+
+#### ignoreLinksFromPartialMatches: Array
+
+An array of paths to be ignored when dynamically imported based on match of string anywhere within the path. When the component loader comes across a `<link>` in your components it dynamically imports the value of href attribute.  
 
 #### ignorePathReWrite: Array
 

--- a/index.js
+++ b/index.js
@@ -55,6 +55,7 @@ class ProcessHtml {
 
     let returnValue = '';
     const ignoreLinks = this.options.ignoreLinks || [];
+    const ignoreLinksFromPartialMatches = this.options.ignoreLinksFromPartialMatches || [];
     const ignorePathReWrites = this.options.ignorePathReWrite || [];
     links.forEach((linkNode) => {
       let href = dom5.getAttribute(linkNode, 'href') || '';
@@ -68,9 +69,16 @@ class ProcessHtml {
         } else {
           path = href;
         }
-        if (ignoreLinks.indexOf(href) < 0) {
+
+        const ignoredFromPartial = ignoreLinksFromPartialMatches.filter(partial => {
+            return href.indexOf(partial) >= 0;
+        });
+
+        if (ignoreLinks.indexOf(href) < 0 && ignoredFromPartial.length === 0) {
           returnValue += `\nimport '${path}';\n`;
         }
+
+
       }
     });
     return returnValue;


### PR DESCRIPTION
Gives users the ability to ignore link hrefs based on matching strings anywhere within link href. Useful for ignoring links with hrefs that start with http:// or https:// for example.